### PR TITLE
Add loongarch64 support.

### DIFF
--- a/include/k/kDefs.h
+++ b/include/k/kDefs.h
@@ -196,6 +196,8 @@
 #define K_ARCH_RISCV_64         (13 | K_ARCH_BIT_64 | K_ARCH_END_LITTLE)
 /** 64-bit RISC-V, big endian. */
 #define K_ARCH_RISCV_64_BE      (13 | K_ARCH_BIT_64 | K_ARCH_END_BIG)
+/** 64-bit LoongArch. */
+#define K_ARCH_LOONGARCH_64     (14 | K_ARCH_BIT_64 | K_ARCH_END_LITTLE)
 /** The end of the valid architecture values (exclusive). */
 #define K_ARCH_MAX              (12+1)
 /** @} */
@@ -222,6 +224,8 @@
 #  define K_ARCH    K_ARCH_PARISC_64
 # elif defined(__hppa__)
 #  define K_ARCH    K_ARCH_PARISC_32
+# elif defined(__loongarch64)
+#  define K_ARCH    K_ARCH_LOONGARCH_64
 # elif defined(__m68k__)
 #  define K_ARCH    K_ARCH_M68K
 # elif defined(__mips64)


### PR DESCRIPTION
Hi maintainer,

kStuff is included in Debian kbuild source package(e.g. kbuild-0.1.9998svn3606+dfsg/src/lib/kStuff).
I have added patch for Debian kbuild.
Debian kbuild was built successfully for loongarch64.
The details can be found at https://buildd.debian.org/status/logs.php?pkg=kbuild&ver=1%3A0.1.9998svn3606%2Bdfsg-2&arch=loong64&suite=sid.

Please review this commit.

Best regards,
Dandan Zhang